### PR TITLE
Fix: migrate domain specific errors into their module

### DIFF
--- a/__tests__/application/errors/common.errors.test.ts
+++ b/__tests__/application/errors/common.errors.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  CustomError,
+  ValidationError,
+  DatabaseError,
+  AuthenticationError,
+  AuthorizationError,
+  ResourceNotFoundError,
+  ResourceConflictError,
+  InternalServerError,
+  HttpStatus,
+  ErrorCodes,
+} from '../../../src/modules/shared/application/errors/common.errors';
+import { DomainException } from '../../../src/modules/shared/domain/exceptions/domain.exception';
+
+describe('HttpStatus Constants', () => {
+  it('should have correct HTTP status codes', () => {
+    expect(HttpStatus.BAD_REQUEST).toBe(400);
+    expect(HttpStatus.UNAUTHORIZED).toBe(401);
+    expect(HttpStatus.FORBIDDEN).toBe(403);
+    expect(HttpStatus.NOT_FOUND).toBe(404);
+    expect(HttpStatus.CONFLICT).toBe(409);
+    expect(HttpStatus.INTERNAL_SERVER_ERROR).toBe(500);
+  });
+});
+
+describe('ErrorCodes Constants', () => {
+  it('should have correct error codes', () => {
+    expect(ErrorCodes.VALIDATION_ERROR).toBe('VALIDATION_ERROR');
+    expect(ErrorCodes.DATABASE_ERROR).toBe('DATABASE_ERROR');
+    expect(ErrorCodes.AUTHENTICATION_ERROR).toBe('AUTHENTICATION_ERROR');
+    expect(ErrorCodes.AUTHORIZATION_ERROR).toBe('AUTHORIZATION_ERROR');
+    expect(ErrorCodes.RESOURCE_NOT_FOUND).toBe('RESOURCE_NOT_FOUND');
+    expect(ErrorCodes.RESOURCE_CONFLICT).toBe('RESOURCE_CONFLICT');
+    expect(ErrorCodes.INTERNAL_ERROR).toBe('INTERNAL_ERROR');
+  });
+});
+
+describe('CustomError', () => {
+  it('should create a custom error with all properties', () => {
+    const code = 'TEST_ERROR';
+    const message = 'Test error message';
+    const statusCode = 400;
+    const details = { field: 'test' };
+
+    const error = new CustomError(code, message, statusCode, details);
+
+    expect(error).toBeInstanceOf(DomainException);
+    expect(error.code).toBe(code);
+    expect(error.message).toBe(message);
+    expect(error.statusCode).toBe(statusCode);
+    expect(error.details).toEqual(details);
+    expect(error.name).toBe('CustomError');
+  });
+
+  it('should create a custom error without details', () => {
+    const code = 'TEST_ERROR';
+    const message = 'Test error message';
+    const statusCode = 400;
+
+    const error = new CustomError(code, message, statusCode);
+
+    expect(error.code).toBe(code);
+    expect(error.message).toBe(message);
+    expect(error.statusCode).toBe(statusCode);
+    expect(error.details).toBeUndefined();
+  });
+
+  it('should serialize to JSON correctly', () => {
+    const error = new CustomError('TEST_ERROR', 'Test message', 400, { field: 'test' });
+    const json = error.toJSON();
+
+    expect(json).toEqual({
+      statusCode: 400,
+      message: 'Test message',
+      errorCode: 'TEST_ERROR',
+      details: { field: 'test' }
+    });
+  });
+
+  it('should serialize to JSON without details when not provided', () => {
+    const error = new CustomError('TEST_ERROR', 'Test message', 400);
+    const json = error.toJSON();
+
+    expect(json).toEqual({
+      statusCode: 400,
+      message: 'Test message',
+      errorCode: 'TEST_ERROR'
+    });
+  });
+});
+
+describe('ValidationError', () => {
+  it('should create a validation error with correct properties', () => {
+    const message = 'Validation failed';
+    const details = { field: 'email', reason: 'invalid format' };
+
+    const error = new ValidationError(message, details);
+
+    expect(error).toBeInstanceOf(CustomError);
+    expect(error).toBeInstanceOf(DomainException);
+    expect(error.code).toBe(ErrorCodes.VALIDATION_ERROR);
+    expect(error.message).toBe(message);
+    expect(error.statusCode).toBe(HttpStatus.BAD_REQUEST);
+    expect(error.details).toEqual(details);
+    expect(error.name).toBe('ValidationError');
+  });
+
+  it('should create a validation error without details', () => {
+    const message = 'Validation failed';
+    const error = new ValidationError(message);
+
+    expect(error.message).toBe(message);
+    expect(error.details).toBeUndefined();
+  });
+});
+
+describe('DatabaseError', () => {
+  it('should create a database error with correct properties', () => {
+    const message = 'Database connection failed';
+    const details = { connectionString: 'redacted' };
+
+    const error = new DatabaseError(message, details);
+
+    expect(error).toBeInstanceOf(CustomError);
+    expect(error.code).toBe(ErrorCodes.DATABASE_ERROR);
+    expect(error.message).toBe(message);
+    expect(error.statusCode).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+    expect(error.details).toEqual(details);
+  });
+});
+
+describe('AuthenticationError', () => {
+  it('should create an authentication error with correct properties', () => {
+    const message = 'Invalid credentials';
+
+    const error = new AuthenticationError(message);
+
+    expect(error).toBeInstanceOf(CustomError);
+    expect(error.code).toBe(ErrorCodes.AUTHENTICATION_ERROR);
+    expect(error.message).toBe(message);
+    expect(error.statusCode).toBe(HttpStatus.UNAUTHORIZED);
+  });
+});
+
+describe('AuthorizationError', () => {
+  it('should create an authorization error with correct properties', () => {
+    const message = 'Access denied';
+
+    const error = new AuthorizationError(message);
+
+    expect(error).toBeInstanceOf(CustomError);
+    expect(error.code).toBe(ErrorCodes.AUTHORIZATION_ERROR);
+    expect(error.message).toBe(message);
+    expect(error.statusCode).toBe(HttpStatus.FORBIDDEN);
+  });
+});
+
+describe('ResourceNotFoundError', () => {
+  it('should create a resource not found error with correct properties', () => {
+    const message = 'User not found';
+    const details = { userId: '123' };
+
+    const error = new ResourceNotFoundError(message, details);
+
+    expect(error).toBeInstanceOf(CustomError);
+    expect(error.code).toBe(ErrorCodes.RESOURCE_NOT_FOUND);
+    expect(error.message).toBe(message);
+    expect(error.statusCode).toBe(HttpStatus.NOT_FOUND);
+    expect(error.details).toEqual(details);
+  });
+});
+
+describe('ResourceConflictError', () => {
+  it('should create a resource conflict error with correct properties', () => {
+    const message = 'Email already exists';
+
+    const error = new ResourceConflictError(message);
+
+    expect(error).toBeInstanceOf(CustomError);
+    expect(error.code).toBe(ErrorCodes.RESOURCE_CONFLICT);
+    expect(error.message).toBe(message);
+    expect(error.statusCode).toBe(HttpStatus.CONFLICT);
+  });
+});
+
+describe('InternalServerError', () => {
+  it('should create an internal server error with default message', () => {
+    const error = new InternalServerError();
+
+    expect(error).toBeInstanceOf(CustomError);
+    expect(error.code).toBe(ErrorCodes.INTERNAL_ERROR);
+    expect(error.message).toBe('Internal server error');
+    expect(error.statusCode).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+  });
+
+  it('should create an internal server error with custom message', () => {
+    const message = 'Something went wrong';
+    const details = { trace: 'stack trace here' };
+
+    const error = new InternalServerError(message, details);
+
+    expect(error.message).toBe(message);
+    expect(error.details).toEqual(details);
+  });
+});
+
+describe('Error Inheritance and Type Checking', () => {
+  it('should maintain proper inheritance chain', () => {
+    const error = new ValidationError('Test validation error');
+
+    expect(error instanceof ValidationError).toBe(true);
+    expect(error instanceof CustomError).toBe(true);
+    expect(error instanceof DomainException).toBe(true);
+    expect(error instanceof Error).toBe(true);
+  });
+
+  it('should be distinguishable by type', () => {
+    const validationError = new ValidationError('Validation failed');
+    const databaseError = new DatabaseError('Database failed');
+
+    expect(validationError instanceof ValidationError).toBe(true);
+    expect(validationError instanceof DatabaseError).toBe(false);
+    expect(databaseError instanceof DatabaseError).toBe(true);
+    expect(databaseError instanceof ValidationError).toBe(false);
+  });
+});
+
+describe('Error Simulation Tests', () => {
+  it('should simulate validation error being thrown', async () => {
+    const simulateValidationError = async () => {
+      throw new ValidationError('Invalid input');
+    };
+
+    await expect(simulateValidationError()).rejects.toThrow(ValidationError);
+    await expect(simulateValidationError()).rejects.toThrow('Invalid input');
+  });
+
+  it('should simulate database error being thrown', async () => {
+    const simulateDatabaseError = async () => {
+      throw new DatabaseError('Connection timeout');
+    };
+
+    await expect(simulateDatabaseError()).rejects.toThrow(DatabaseError);
+    await expect(simulateDatabaseError()).rejects.toThrow('Connection timeout');
+  });
+
+  it('should simulate authentication error being thrown', async () => {
+    const simulateAuthError = async () => {
+      throw new AuthenticationError('Invalid token');
+    };
+
+    await expect(simulateAuthError()).rejects.toThrow(AuthenticationError);
+    await expect(simulateAuthError()).rejects.toThrow('Invalid token');
+  });
+}); 

--- a/__tests__/application/errors/volunteer-registration.errors.test.ts
+++ b/__tests__/application/errors/volunteer-registration.errors.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  VolunteerRegistrationError,
+  VolunteerPositionFullError,
+  VolunteerAlreadyRegisteredError,
+  VolunteerNotFoundError,
+} from '../../../src/modules/volunteer/application/errors/volunteer-registration.errors';
+import { DomainException } from '../../../src/modules/shared/domain/exceptions/domain.exception';
+
+describe('VolunteerRegistrationError', () => {
+  it('should create an error with a custom message', () => {
+    const customMessage = 'Custom registration error';
+    const error = new VolunteerRegistrationError(customMessage);
+
+    expect(error.message).toBe(customMessage);
+    expect(error).toBeInstanceOf(DomainException);
+    expect(error.name).toBe('VolunteerRegistrationError');
+  });
+
+  it('should be an instance of DomainException', () => {
+    const error = new VolunteerRegistrationError('Test message');
+
+    expect(error instanceof VolunteerRegistrationError).toBe(true);
+    expect(error instanceof DomainException).toBe(true);
+  });
+});
+
+describe('VolunteerPositionFullError', () => {
+  it('should create an error with the correct message and properties', () => {
+    const error = new VolunteerPositionFullError();
+
+    expect(error).toBeInstanceOf(DomainException);
+    expect(error.message).toBe('Volunteer position is full');
+    expect(error.name).toBe('VolunteerPositionFullError');
+  });
+
+  it('should extend VolunteerRegistrationError', () => {
+    const error = new VolunteerPositionFullError();
+
+    expect(error instanceof VolunteerPositionFullError).toBe(true);
+    expect(error instanceof VolunteerRegistrationError).toBe(true);
+    expect(error instanceof DomainException).toBe(true);
+  });
+});
+
+describe('VolunteerAlreadyRegisteredError', () => {
+  it('should create an error with the correct message and properties', () => {
+    const error = new VolunteerAlreadyRegisteredError();
+
+    expect(error).toBeInstanceOf(DomainException);
+    expect(error.message).toBe('User is already registered for this volunteer position');
+    expect(error.name).toBe('VolunteerAlreadyRegisteredError');
+  });
+
+  it('should extend VolunteerRegistrationError', () => {
+    const error = new VolunteerAlreadyRegisteredError();
+
+    expect(error instanceof VolunteerAlreadyRegisteredError).toBe(true);
+    expect(error instanceof VolunteerRegistrationError).toBe(true);
+    expect(error instanceof DomainException).toBe(true);
+  });
+});
+
+describe('VolunteerNotFoundError', () => {
+  it('should create an error with the correct message and properties', () => {
+    const error = new VolunteerNotFoundError();
+
+    expect(error).toBeInstanceOf(DomainException);
+    expect(error.message).toBe('Volunteer position not found');
+    expect(error.name).toBe('VolunteerNotFoundError');
+  });
+
+  it('should extend VolunteerRegistrationError', () => {
+    const error = new VolunteerNotFoundError();
+
+    expect(error instanceof VolunteerNotFoundError).toBe(true);
+    expect(error instanceof VolunteerRegistrationError).toBe(true);
+    expect(error instanceof DomainException).toBe(true);
+  });
+});
+
+describe('Error Simulation Tests', () => {
+  it('should simulate VolunteerNotFoundError being thrown', async () => {
+    const simulateVolunteerNotFound = async () => {
+      throw new VolunteerNotFoundError();
+    };
+
+    await expect(simulateVolunteerNotFound()).rejects.toThrow(VolunteerNotFoundError);
+    await expect(simulateVolunteerNotFound()).rejects.toThrow('Volunteer position not found');
+  });
+
+  it('should simulate VolunteerPositionFullError being thrown', async () => {
+    const simulatePositionFull = async () => {
+      throw new VolunteerPositionFullError();
+    };
+
+    await expect(simulatePositionFull()).rejects.toThrow(VolunteerPositionFullError);
+    await expect(simulatePositionFull()).rejects.toThrow('Volunteer position is full');
+  });
+
+  it('should simulate VolunteerAlreadyRegisteredError being thrown', async () => {
+    const simulateAlreadyRegistered = async () => {
+      throw new VolunteerAlreadyRegisteredError();
+    };
+
+    await expect(simulateAlreadyRegistered()).rejects.toThrow(VolunteerAlreadyRegisteredError);
+    await expect(simulateAlreadyRegistered()).rejects.toThrow('User is already registered for this volunteer position');
+  });
+
+  it('should simulate generic VolunteerRegistrationError being thrown', async () => {
+    const simulateGenericError = async () => {
+      throw new VolunteerRegistrationError('Generic registration error');
+    };
+
+    await expect(simulateGenericError()).rejects.toThrow(VolunteerRegistrationError);
+    await expect(simulateGenericError()).rejects.toThrow('Generic registration error');
+  });
+});
+
+describe('Error Serialization', () => {
+  it('should properly serialize error information', () => {
+    const error = new VolunteerPositionFullError();
+    const errorJson = JSON.parse(JSON.stringify(error));
+
+    expect(errorJson.message).toBe('Volunteer position is full');
+    expect(errorJson.name).toBe('VolunteerPositionFullError');
+  });
+
+  it('should maintain error inheritance in catch blocks', () => {
+    try {
+      throw new VolunteerAlreadyRegisteredError();
+    } catch (error) {
+      expect(error).toBeInstanceOf(VolunteerAlreadyRegisteredError);
+      expect(error.name).toBe('VolunteerAlreadyRegisteredError');
+      expect(error.message).toBe('User is already registered for this volunteer position');
+    }
+  });
+}); 

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { CustomError, InternalServerError } from "../errors";
+import { CustomError, InternalServerError } from "../modules/shared/application/errors";
 import { createLogger } from "../services/logger.service";
 
 const logger = createLogger('ERROR_HANDLER');

--- a/src/modules/shared/application/errors/common.errors.ts
+++ b/src/modules/shared/application/errors/common.errors.ts
@@ -1,23 +1,4 @@
-export class CustomError extends Error {
-  constructor(
-    public code: string,
-    public message: string,
-    public statusCode: number,
-    public details?: Record<string, unknown>
-  ) {
-    super(message);
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-
-  public toJSON() {
-    return {
-      statusCode: this.statusCode,
-      message: this.message,
-      errorCode: this.code,
-      ...(this.details && { details: this.details }),
-    };
-  }
-}
+import { DomainException } from "../../domain/exceptions/domain.exception";
 
 // HTTP Status codes for different types of errors
 export const HttpStatus = {
@@ -39,6 +20,33 @@ export const ErrorCodes = {
   RESOURCE_CONFLICT: "RESOURCE_CONFLICT",
   INTERNAL_ERROR: "INTERNAL_ERROR",
 } as const;
+
+export class CustomError extends DomainException {
+  public readonly code: string;
+  public readonly statusCode: number;
+  public readonly details?: Record<string, unknown>;
+
+  constructor(
+    code: string,
+    message: string,
+    statusCode: number,
+    details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+
+  public toJSON() {
+    return {
+      statusCode: this.statusCode,
+      message: this.message,
+      errorCode: this.code,
+      ...(this.details && { details: this.details }),
+    };
+  }
+}
 
 export class ValidationError extends CustomError {
   constructor(message: string, details?: Record<string, unknown>) {
@@ -113,4 +121,4 @@ export class InternalServerError extends CustomError {
       details
     );
   }
-}
+} 

--- a/src/modules/shared/application/errors/index.ts
+++ b/src/modules/shared/application/errors/index.ts
@@ -1,0 +1,12 @@
+export {
+  HttpStatus,
+  ErrorCodes,
+  CustomError,
+  ValidationError,
+  DatabaseError,
+  AuthenticationError,
+  AuthorizationError,
+  ResourceNotFoundError,
+  ResourceConflictError,
+  InternalServerError,
+} from './common.errors'; 

--- a/src/modules/volunteer/application/errors/index.ts
+++ b/src/modules/volunteer/application/errors/index.ts
@@ -1,0 +1,6 @@
+export {
+  VolunteerRegistrationError,
+  VolunteerPositionFullError,
+  VolunteerAlreadyRegisteredError,
+  VolunteerNotFoundError,
+} from './volunteer-registration.errors';

--- a/src/modules/volunteer/application/errors/volunteer-registration.errors.ts
+++ b/src/modules/volunteer/application/errors/volunteer-registration.errors.ts
@@ -1,31 +1,25 @@
-export class VolunteerRegistrationError extends Error {
+import { DomainException } from "../../../shared/domain/exceptions/domain.exception";
+
+export class VolunteerRegistrationError extends DomainException {
   constructor(message: string) {
     super(message);
-    this.name = 'VolunteerRegistrationError';
   }
 }
 
 export class VolunteerPositionFullError extends VolunteerRegistrationError {
   constructor() {
     super('Volunteer position is full');
-    this.name = 'VolunteerPositionFullError';
   }
 }
 
 export class VolunteerAlreadyRegisteredError extends VolunteerRegistrationError {
   constructor() {
     super('User is already registered for this volunteer position');
-    this.name = 'VolunteerAlreadyRegisteredError';
   }
 }
 
 export class VolunteerNotFoundError extends VolunteerRegistrationError {
   constructor() {
     super('Volunteer position not found');
-    this.name = 'VolunteerNotFoundError';
   }
-}
-
-export class UserVolunteerService {
-  // ... rest of the class implementation
 } 

--- a/src/services/OrganizationService.ts
+++ b/src/services/OrganizationService.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from "@prisma/client";
-import { ValidationError } from "../errors";
+import { ValidationError } from "../modules/shared/application/errors";
 import { Prisma, Organization, NFT } from "@prisma/client";
 
 type OrganizationWithNFTs = Prisma.OrganizationGetPayload<{

--- a/src/services/ProjectService.ts
+++ b/src/services/ProjectService.ts
@@ -3,7 +3,7 @@ import { Project } from "../entities/Project"
 import { Volunteer } from "../entities/Volunteer"
 import { withTransaction } from "../utils/transaction.helper"
 import { Logger } from "../utils/logger"
-import { ValidationError, DatabaseError } from "../errors"
+import { ValidationError, DatabaseError } from "../modules/shared/application/errors"
 
 // Define types based on the Prisma schema
 interface PrismaProject {

--- a/src/services/__tests__/userVolunteer.service.test.ts
+++ b/src/services/__tests__/userVolunteer.service.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach, jest } from '@jest/globals';
 import { UserVolunteerService } from '../userVolunteer.service';
 import { PrismaClient, Prisma, User, Volunteer, UserVolunteer } from '@prisma/client';
 import { DeepMockProxy, mockDeep } from 'jest-mock-extended';
-import { VolunteerAlreadyRegisteredError, VolunteerNotFoundError, VolunteerPositionFullError } from '../../errors/VolunteerRegistrationError';
+import { VolunteerAlreadyRegisteredError, VolunteerNotFoundError, VolunteerPositionFullError } from '../../modules/volunteer/application/errors';
 
 // Mock PrismaClient with proper type
 const mockPrisma: DeepMockProxy<PrismaClient> = mockDeep<PrismaClient>();

--- a/src/services/userVolunteer.service.ts
+++ b/src/services/userVolunteer.service.ts
@@ -3,7 +3,7 @@ import {
   VolunteerAlreadyRegisteredError,
   VolunteerNotFoundError,
   VolunteerPositionFullError,
-} from "../errors/VolunteerRegistrationError";
+} from "../modules/volunteer/application/errors";
 
 export class UserVolunteerService {
   constructor(private prisma: PrismaClient) {}

--- a/tests/middlewares/errorHandler.test.ts
+++ b/tests/middlewares/errorHandler.test.ts
@@ -6,7 +6,7 @@ import {
   ResourceNotFoundError,
   InternalServerError,
   CustomError,
-} from "../../src/errors";
+} from "../../src/modules/shared/application/errors";
 
 describe("Error Handler Middleware", () => {
   let mockRequest: Partial<Request>;


### PR DESCRIPTION
# 🚀 Volunchain Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [x] Closes #130
- [x] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting
- [ ] Evidence attached
- [ ] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description
I successfully migrated all domain-specific errors from the legacy src/errors/ directory to their appropriate modules under the new architecture. 

---

## 📸 Evidence (A photo is required as evidence)



---

## ⏰ Time spent breakdown
4 hours


---

## 🌌 Comments



---

Thank you for contributing to Volunchain, we are glad that you have chosen us as your project of choice and we hope that you continue to contribute to this great project, so that together we can make our mark at the top!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized and reorganized error class exports for easier imports across the application.
  * Updated error class inheritance to use domain-specific base exceptions.
  * Adjusted import paths for error classes throughout the codebase for consistency.

* **Tests**
  * Added comprehensive tests for custom error classes, including volunteer registration and shared errors, ensuring correct behavior, inheritance, and serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->